### PR TITLE
Added devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-bicep",
+				"ms-python.python",
+				"ms-python.pylint"
+			]
+		}
+	}
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "msazurermtools.azurerm-vscode-tools"
+    ]
+}


### PR DESCRIPTION
Added simple devcontainer for anyone using Codespaces or VSCode.

This devcontainer includes:

- [Universal image](https://github.com/devcontainers/images/tree/main/src/universal)
- az cli 
- python
- pylint
- bicep 

I've added ARM extension as a recommendation because it seemed a little clunky as it starts a server. 