### PR TITLE
Updated core image docker file

### DIFF
--- a/Runner-Images/CHANGELOG.md
+++ b/Runner-Images/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Change Log
 
+## Version 1.1.0
+Updated Azure CLI base image moving from [Alpine to Mariner Linux](https://techcommunity.microsoft.com/blog/azuretoolsblog/azure-cli-docker-container-base-linux-image-is-now-azure-linux/4236248). Has the potential to break new builds. Namely, commands such as `apk add` will likely fail. To fix the issue, use `tdnf install` to install all packages. For example:
+
+Before:
+```dockerfile
+RUN apk add curl
+```
+
+After:
+```dockerfile
+RUN apk add curl || \
+    (echo "Failed to install curl with apk, trying with tdnf" && \
+    tdnf install -y tar gzip && \
+    tdnf install -y curl)
+```
+
 ## Version 2.9.0-preview
 Fixed a number of bugs around output type serialization, and added the 'ade upgrade' functionality to ensure up-to-date CLI actions regardless of the base image.

--- a/Runner-Images/CHANGELOG.md
+++ b/Runner-Images/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Version 1.1.0
+## Version 4.0.0-preview
 Updated Azure CLI base image moving from [Alpine to Mariner Linux](https://techcommunity.microsoft.com/blog/azuretoolsblog/azure-cli-docker-container-base-linux-image-is-now-azure-linux/4236248). Has the potential to break new builds. Namely, commands such as `apk add` will likely fail. To fix the issue, use `tdnf install` to install all packages. For example:
 
 Before:

--- a/Runner-Images/Core/Dockerfile
+++ b/Runner-Images/Core/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:2.67.0
 WORKDIR /
 
 ARG IMAGE_VERSION
@@ -9,8 +9,12 @@ ARG IMAGE_VERSION
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 
-# Add jq for parsing JSON
-RUN apk add jq
+# Install jq, dos2unix, libicu, wget & unzip
+RUN tdnf install -y jq
+RUN tdnf install -y dos2unix
+RUN tdnf install -y libicu
+RUN tdnf install -y wget
+RUN tdnf install -y unzip
 
 COPY entrypoint.sh /entrypoint.sh
 COPY shared/* /shared/


### PR DESCRIPTION
Updated core image docker file to build based off of updated AZ CLI image. This change moves the core image from Alpine Linux to Mariner. Change log is updated to reflect steps required for custom runner images to continue to work based off of new core image.